### PR TITLE
Add an example pipeline for 2 environment branches "master" and "production"

### DIFF
--- a/ci/2-envs.yml
+++ b/ci/2-envs.yml
@@ -1,0 +1,263 @@
+groups:
+  - name: master
+    jobs:
+      - test-pull-request
+      - test-master
+      - ship-master
+      - integrate-master
+      - patch
+      - minor
+      - major
+      - rc
+
+  - name: production
+    jobs:
+      - merge-master-to-production
+      - test-production
+      - ship-production
+
+resource_types:
+  - name: pull-request
+    type: docker-image
+    source:
+      repository: jtarchie/pr
+
+resources:
+  - name: repo-master
+    type: git
+    source:
+      uri: {{github-repo-uri}}
+      branch: master
+      private_key: {{github-private-key}}
+
+  - name: repo-production
+    type: git
+    source:
+      uri: {{github-repo-uri}}
+      branch: production
+      private_key: {{github-private-key}}
+
+  - name: pull-request
+    type: pull-request
+    source:
+      access_token: {{github-access-token}}
+      private_key: {{github-private-key}}
+      repo: {{github-repo-name}}
+      every: true
+
+  - name: rc-version
+    type: semver
+    source:
+      driver: git
+      uri: {{github-repo-uri}}
+      branch: version/rc
+      private_key: {{github-private-key}}
+      file: version
+      initial_version: {{initial-version}}
+
+  - name: final-version
+    type: semver
+    source:
+      driver: git
+      uri: {{github-repo-uri}}
+      branch: version/final
+      private_key: {{github-private-key}}
+      file: rc-version
+      initial_version: {{initial-version}}
+
+jobs:
+
+  - name: test-pr
+    plan:
+    - get: pull-request
+      resource: pull-request
+      version: every
+      trigger: true
+    - put: pull-request
+      params:
+        path: pull-request
+        status: pending
+    - task: test-pull-request
+      file: repo/ci/tasks/unit.yml
+      input_mapping: { repo: pull-request }
+      on_success:
+        put: pull-request
+        params:
+          path: pull-request
+          status: success
+      on_failure:
+        put: pull-request
+        params:
+          path: pull-request
+          status: failure
+
+  - name: test-master
+    plan:
+      - get: master
+        resource: repo-master
+        trigger: true
+      - task: unit
+        file: repo/ci/tasks/unit.yml
+        input_mapping: { repo: master }
+
+  - name: integrate-master
+    serial: true
+    plan:
+      - aggregate:
+        - get: master
+          resource: repo-master
+          trigger: true
+          passed: [ test-master ]
+      - task: integration-test
+        file: repo/ci/tasks/integration.yml
+        input_mapping: {repo: master}
+
+  - name: version-master
+    serial: true
+    serial_groups: [ update-version ]
+    plan:
+      - aggregate:
+        - get: master
+          resource: repo-master
+          trigger: true
+          passed: [ integrate-master]
+        - get: rc-version
+      - put: rc-version
+        params: { pre: rc }
+
+  - name: ship-master
+    serial: true
+    plan:
+      - aggregate:
+        - get: master
+          resource: repo-master
+          trigger: true
+          passed: [ version-master ]
+        - get: rc-version
+          passed: [ version-master ]
+      - task: ship
+        file: repo/ci/tasks/shipit.yml
+        input_mapping: { repo: master, version: rc-version }
+
+  - name: merge-master-to-production
+    serial: true
+    plan:
+      - aggregate:
+        - get: master
+          resource: repo-master
+          passed: [ ship-master ]
+        - get: production
+          resource: repo-production
+      - task: merge-master-to-production
+        file: master/ci/tasks/merge-branch.yml
+        input_mapping: { from: master, to: production }
+        output_mapping: { out: next-production }
+        params:
+          GIT_EMAIL: {{git-email}}
+          GIT_NAME: {{git-name}}
+          NO_FF: true
+      - put: production
+        resource: repo-production
+        params:
+          repository: next-production
+
+  - name: test-production
+    serial: true
+    plan:
+      - get: production
+        resource: repo-production
+        # comment out next line for support hotfix
+        passed: [ merge-master-to-production ]
+        trigger: true
+      - task: unit-on-production
+        file: repo/ci/tasks/unit.yml
+        input_mapping: { repo: production }
+
+  - name: version-production
+    serial: true
+    plan:
+      - aggregate:
+        - get: production
+          resource: repo-production
+          passed: [ test-production ]
+          trigger: true
+        - get: rc-version
+          params: { bump: final }
+      - put: final-version
+        params: { file: rc-version/version }
+
+  - name: tag-production
+    serial: true
+    plan:
+      - aggregate:
+        - get: production
+          resource: repo-production
+          passed: [ version-production ]
+          trigger: true
+        - get: final-version
+          passed: [ version-production ]
+      - put: production
+        resource: repo-production
+        params:
+          repository: production
+          tag: final-version/version
+
+  - name: ship-production
+    serial: true
+    plan:
+      - get: production
+        resource: repo-production
+        passed: [ tag-production ]
+        #Uncomment this line for CD
+        #trigger: true
+      - get: final-version
+        passed: [ tag-production ]
+      - task: ship-production
+        file: repo/ci/tasks/shipit.yml
+        input_mapping: { repo: production, version: final-version }
+
+  - name: start-next-rc
+    serial: true
+    serial_groups: [ update-version ]
+    plan:
+      - get: final-version
+        passed: [ tag-production ]
+        trigger: true
+      - put: rc-version
+        params: { file: final-version/version, bump: patch, pre: rc }
+
+
+# semver control
+  - name: patch
+    serial: true
+    serial_groups: [ update-version ]
+    plan:
+      - get: rc-version
+      - put: rc-version
+        params: { bump: patch, pre: rc }
+      - get: rc-version
+        parms: { pre: beta }
+
+  - name: minor
+    serial: true
+    serial_groups: [ update-version ]
+    plan:
+      - get: rc-version
+      - put: rc-version
+        params: { bump: minor, pre: rc }
+
+  - name: major
+    serial: true
+    serial_groups: [ update-version ]
+    plan:
+      - get: rc-version
+      - put: rc-version
+        params: { bump: major, pre: rc }
+
+  - name: rc
+    serial: true
+    serial_groups: [ update-version ]
+    plan:
+      - get: rc-version
+      - put: rc-version
+        parms: { pre: rc }

--- a/ci/tasks/merge-branch.yml
+++ b/ci/tasks/merge-branch.yml
@@ -1,0 +1,17 @@
+---
+platform: linux
+image_resource:
+  type: docker-image
+  source:
+    repository: getourneau/alpine-bash-git
+inputs:
+  - name: from
+    path: repo-target
+  - name: to
+    path: repo
+outputs:
+  - name: out
+run:
+  path: /bin/bash
+  args:
+    - repo-target/ci/tasks/merge.sh


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/22009/18197921/d4c67c78-7134-11e6-9589-b21e37bb7884.png)
- I've defined 2 `version` resources: `rc-version` and `final-version`
  - `rc-version` for tagging commits in the `master` branch
  - `final-version` for tagging commits in the `production` branch
  - `final-version` is always computed from the latest `rc-version`
    - so that `final-version` is `x.y.z` where the rc version is `x.y.z.rc.xxx` when the master branch is merged to production
    - no matter whether `x.y.z` is actually shipped to production or not, you can independently develop next rc `x.y.z+1.rc.1` (see the `start-next-rc` job)
      - i.e. If you like, you can choose not to run `ship-production` after the `production` branch is tagged with `x.y.z`(see the `version-production` job), and pipeline still works without any problem
- Split versioning job and shipping job so you can try to manually re-deploy the app in case of a deployment failure (without bumping semver just for re-deployment. see `version-production` and `ship-production`)
- As `production` branch is not a release branch, anything other than merge commits are forbidden in it. So we don't have to unit/integration test the new commits in the `production` branch. Test it only when `master` is merged to `production`.
  - i.e. you don't need cherry-picking commits that are only in the `production` branch, because you can't make `hotfix` commits directly into the `production` branch
